### PR TITLE
Fix IMGUI control count mismatch when scrolling parameter list

### DIFF
--- a/Editor/VRCSDKPlus.cs
+++ b/Editor/VRCSDKPlus.cs
@@ -149,7 +149,7 @@ namespace DreadScripts.VRCSDKPlus
                 using (new GUILayout.HorizontalScope("helpbox"))
                     DrawAdvancedAvatarFull(ref avatar, validAvatars, RefreshValidParameters, false, false, false, "Active Avatar");
 
-                canCleanup = false;
+                canCleanup = _parameterStatus != null && _parameterStatus.Any(s => s.hasWarning);
                 serializedObject.Update();
                 HandleParameterEvents();
                 parametersOrderList.DoLayoutList();
@@ -280,7 +280,6 @@ namespace DreadScripts.VRCSDKPlus
             private void DrawElement(Rect rect, int index, bool active, bool focused)
             {
                 if (!(index < parameterList.arraySize && index >= 0)) return;
-                
                 var screenRect = GUIUtility.GUIToScreenRect(rect);
                 if (screenRect.y > Screen.currentResolution.height || screenRect.y + screenRect.height < 0) return;
 
@@ -298,8 +297,6 @@ namespace DreadScripts.VRCSDKPlus
                 bool hasWarning = status.hasWarning;
                 string warnMsg = parameterEmpty ? "Blank Parameter" : parameterIsDuplicate ? "Duplicate Parameter! May cause issues!" : "Parameter not found in any playable controller of Active Avatar";
                 AnimatorControllerParameter matchedParameter = status.matchedParameter;
-
-                canCleanup |= hasWarning;
 
                 #region Rects
                 rect.y += 1;


### PR DESCRIPTION
## Problem

When scrolling the parameter list about half-way, the scrolling would stop working (Scrolling with mouse wheel, but not with the UI slider) and an error would occur in the Unity console, saying:
`ArgumentException: Getting control 1's position in a group with only 1 controls when doing repaint`

`canCleanup` was set inside `DrawElement` after a screen-space
visibility cull. During scroll, Layout and Repaint passes can disagree
on which rows are off-screen, making `canCleanup` true in one pass and
false in the other. This causes the cleanup button to exist in one
pass but not the other, throwing an ArgumentException.

## Fix 

Compute `canCleanup` from `_parameterStatus` before `DoLayoutList()`
so it's independent of which rows are currently visible.